### PR TITLE
lowercase attribute names

### DIFF
--- a/AtLeastValidator.php
+++ b/AtLeastValidator.php
@@ -116,6 +116,7 @@ class AtLeastValidator extends Validator
     public function clientValidateAttribute($model, $attribute, $view)
     {
         $attributes = is_array($this->in) ? $this->in : preg_split('/\s*,\s*/', $this->in, -1, PREG_SPLIT_NO_EMPTY);
+        $attributes = array_map('strtolower',$attributes); // yii lowercases attributes
         $attributesJson = json_encode($attributes);
 
         $attributesLabels = [];


### PR DESCRIPTION
For those tables that use field names that are CamelCase - make all attribute names lowercase, to match what Yii does (when the form is generated, form attribute ids will be all lowercase, so this line fails:

var obj = $('#' + formName + '-' + attr);

if attr is not lowercased
