### PR TITLE
use i18n message labels

### DIFF
--- a/AtLeastValidator.php
+++ b/AtLeastValidator.php
@@ -95,7 +95,7 @@ class AtLeastValidator extends Validator
 
         foreach ($attributes as $attributeName) {
             $value = $model->$attributeName;
-            $attributesListLabels[] = '"' . $model->generateAttributeLabel($attributeName) . '"'; // TODO simplify this
+            $attributesListLabels[] = '"' . $model->getAttributeLabel($attributeName). '"';
             $chosen += !empty($value) ? 1 : 0;
         }
 


### PR DESCRIPTION
This change uses the i18n module when enabled so attribute labels are returned in the localized version.

NOTE this does NOT translate the massage string itself. A quick work around is to add he following to the rules declaration:

```
['body', AtLeastValidator::className(), 'in' => ['body', 'uploadfile'],
            'message' => Yii::t('app', 'You must fill at least {min} of the attributes {attributes}.')],
```

And then in your app messages (example for Dutch):

```
'You must fill at least {min} of the attributes {attributes}.' => 
     'Je moet minimaal {min} van de attributen {attributes} opgeven.'
```

This can be added to the documentation or even add a translation file for this module.
