### PR TITLE
Use of already defined message source config

### DIFF
--- a/AtLeastValidator.php
+++ b/AtLeastValidator.php
@@ -82,7 +82,7 @@ class AtLeastValidator extends Validator
         } elseif (! is_array($this->in) && count(preg_split('/\s*,\s*/', $this->in, -1, PREG_SPLIT_NO_EMPTY)) <= 1) {
             throw new InvalidConfigException('The `in` parameter must have at least 2 attributes.');
         }
-		if (!isset(Yii::$app->get('i18n')->translations['message*'])) {
+		if (!Yii::$app->get('i18n')->getMessageSource('messages')) {
 			Yii::$app->get('i18n')->translations['message*'] = [
 				'class' => PhpMessageSource::className(),
 				'basePath' => __DIR__ . '/messages',


### PR DESCRIPTION
I'm using this validator within an application which is running with language 'de'. I'm getting a warning `The message file for category 'messages' does not exist: .../vendor/codeonyii/yii2-at-least-validator/messages/de/messages.php`. To get rid of this warning message I have to define a message source extra for `message*`. This PR make this extra config obsolete by checking if there is a responsible message source for `messages` defined. Which is in my case a wildcard `*` message source.