### PR TITLE
Escape single quotes for the values that are being passed to Javascript

### DIFF
--- a/AtLeastValidator.php
+++ b/AtLeastValidator.php
@@ -130,7 +130,7 @@ class AtLeastValidator extends Validator
 
         $attributesLabels = [];
         foreach ($attributes as $attr) {
-            $attributesLabels[] = '"' . $model->getAttributeLabel($attr) . '"';
+            $attributesLabels[] = '"' . addcslashes($model->getAttributeLabel($attr), "'") . '"';
         }
         $message = strtr($this->message, [
             '{min}' => $this->min,


### PR DESCRIPTION
In my application I had some labels that had single quotes in them, and didn't get added to the Javascript correctly.